### PR TITLE
Rollup race data from years past

### DIFF
--- a/app/models/grid.rb
+++ b/app/models/grid.rb
@@ -3,5 +3,6 @@ class Grid < ApplicationRecord
   has_many :drivers, through: :positions
   validates :lap, presence: true
   scope :current, ->() {where(year: Time.current.year)}
+  scope :past, ->() {where.not(year: Time.current.year)}
   attribute :year, :integer, default: -> {Time.current.year.to_i}
 end

--- a/lib/tasks/rollup.rake
+++ b/lib/tasks/rollup.rake
@@ -1,0 +1,9 @@
+namespace :fantasy500 do
+  desc "Rolls up data from previous years."
+  task :rollup => :environment do
+    puts "🟢 Rolling up data…"
+    puts "⟶\tPurging historical positions aside from start/finish…"
+    Grid.past.where.not(lap: 0).and(Grid.past.where.not(lap: 200)).destroy_all
+    puts "🔴 Done."
+  end
+end


### PR DESCRIPTION
Removing all of the intermediary grids for past races frees up quite a few records to stay under Heroku's free limit.